### PR TITLE
Bump shakapacker from 8.2.0 to 8.3.0 (Combined)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 1.14'
 
-gem 'shakapacker', '8.2.0'
+gem 'shakapacker', '8.3.0'
 
 gem 'react_on_rails', '14.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.1)
     drb (2.2.3)
-    erb (5.0.1)
+    erb (5.0.2)
     erubi (1.13.1)
     execjs (2.10.0)
     factory_bot (6.5.4)
@@ -164,7 +164,7 @@ GEM
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
@@ -227,7 +227,7 @@ GEM
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.0)
     rack-proxy (0.7.7)
       rack
     rack-session (2.1.1)
@@ -272,7 +272,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
-    rdoc (6.14.1)
+    rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     react_on_rails (14.2.1)
@@ -282,7 +282,7 @@ GEM
       rails (>= 5.2)
       rainbow (~> 3.0)
     regexp_parser (2.10.0)
-    reline (0.6.1)
+    reline (0.6.2)
       io-console (~> 0.5)
     rexml (3.3.9)
     rspec-core (3.13.3)
@@ -352,7 +352,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.0)
-    shakapacker (8.2.0)
+    shakapacker (8.3.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -442,7 +442,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   selenium-webdriver
-  shakapacker (= 8.2.0)
+  shakapacker (= 8.3.0)
   shoulda-matchers (~> 6.5)
   simplecov
   sprockets-rails

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^19.1.0",
     "react-on-rails": "14.2.1",
     "react-router": "^7.8.1",
-    "shakapacker": "8.2.0",
+    "shakapacker": "8.3.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "5",
     "trix": "^2.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,10 +5819,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-8.2.0.tgz#c7bed87b8be2ae565cfe616f68552be545c77e14"
-  integrity sha512-Ct7BFqJVnKbxdqCzG+ja7Q6LPt/PlB7sSVBfG5jsAvmVCADM05cuoNwEgYNjFGKbDzHAxUqy5XgoI9Y030+JKQ==
+shakapacker@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-8.3.0.tgz#48b8ce16d551a07f59dd95c418962540480affc9"
+  integrity sha512-eJsSSZDMbwmzVzM+Bn2QxAFhdLfcP5prUiDNPrQBGkFazCKjG4b6ZzpUg3rXQGt2l7SPLHQ8BA78QRvPBeBeFA==
   dependencies:
     js-yaml "^4.1.0"
     path-complete-extname "^1.0.0"


### PR DESCRIPTION
## Summary
This PR combines the shakapacker update from both dependabot PRs (#704 and #705) to ensure consistent upgrading across both package managers.

## Changes
- **Bundler**: Updates `Gemfile` and `Gemfile.lock` 
- **NPM/Yarn**: Updates `package.json` and `yarn.lock`

## Why combine?
Shakapacker appears in both Ruby and JavaScript dependencies. The separate dependabot PRs were causing CI failures because only half the update was applied at a time.

## Closes
- Closes #704
- Closes #705

## Changelog
- Allow `webpack-assets-manifest` v6
- Take current `core-js` version from `node_modules` if available  
- Require webpack >= 5.76.0 to reduce CVE-2023-28154 exposure
- More precise types for `devServer` and `rules` configuration