### PR TITLE
Configure rspec-github gem for better CI test reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           RAILS_ENV=test bin/rails db:drop db:create db:schema:load || RAILS_ENV=test bin/rails db:prepare
 
       - name: Run tests
-        run: bin/rspec
+        run: bin/rspec --format progress --format RSpec::Github::Formatter
 
   lint-ruby:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :test do
   gem 'bundler-audit', '~> 0.9', require: false
   gem 'capybara'
   gem 'cucumber-rails', require: false
+  gem 'rspec-github', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,8 @@ GEM
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
+    rspec-github (3.0.0)
+      rspec-core (~> 3.0)
     rspec-its (2.0.0)
       rspec-core (>= 3.13.0)
       rspec-expectations (>= 3.13.0)
@@ -432,6 +434,7 @@ DEPENDENCIES
   rails (~> 8.0.2)
   rails-controller-testing
   react_on_rails (= 14.2.1)
+  rspec-github
   rspec-its (~> 2.0)
   rspec-rails (~> 8.0)
   rubocop (~> 1.79)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# Load the GitHub formatter when running in CI
+require 'rspec/github' if ENV['CI']
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Summary
- Adds the rspec-github gem to improve test failure visibility in GitHub Actions
- Test failures will now appear as inline annotations directly in pull request reviews
- Only loads in CI environment to avoid affecting local development

## Changes
- Added `rspec-github` gem to the test group in Gemfile
- Updated GitHub Actions CI workflow to use the GitHub formatter for RSpec output
- Added conditional loading of the formatter in spec_helper.rb when CI environment variable is set

## Test plan
- [x] Bundle install completed successfully
- [x] Verified formatter loads correctly with --dry-run
- [x] Rubocop passes on modified files
- [ ] CI tests should run and show inline annotations on failures

This will make debugging test failures in pull requests much easier by showing exactly where tests failed right in the GitHub UI\!

🤖 Generated with Claude Code