### PR TITLE
Add GitHub formatters for RuboCop and Cucumber CI annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Security audit application code
         run: bin/brakeman -q -w2
       - name: Lint Ruby files
-        run: bin/rubocop --parallel
+        run: bin/rubocop --parallel --format github
 
   lint-javascript:
     runs-on: ubuntu-latest
@@ -202,4 +202,4 @@ jobs:
         run: bin/rails assets:precompile
 
       - name: Run Cucumber tests
-        run: bundle exec cucumber
+        run: bundle exec cucumber --format CucumberGithubFormatter::Formatter --format pretty

--- a/Gemfile
+++ b/Gemfile
@@ -81,8 +81,10 @@ group :test do
   gem 'brakeman', '~> 7.1', require: false
   gem 'bundler-audit', '~> 0.9', require: false
   gem 'capybara'
+  gem 'cucumber_github_formatter', require: false
   gem 'cucumber-rails', require: false
   gem 'rspec-github', require: false
+  gem 'rubocop-github-annotations-formatter', require: false
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
       cucumber (>= 5, < 10)
       railties (>= 5.2, < 9)
     cucumber-tag-expressions (6.1.2)
+    cucumber_github_formatter (0.1.0)
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
@@ -327,6 +328,8 @@ GEM
     rubocop-factory_bot (2.27.1)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
+    rubocop-github-annotations-formatter (0.1.0)
+      rubocop
     rubocop-graphql (1.5.6)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1, < 2)
@@ -421,6 +424,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   capybara
   cucumber-rails
+  cucumber_github_formatter
   database_cleaner-active_record
   debug
   factory_bot (~> 6.5)
@@ -440,6 +444,7 @@ DEPENDENCIES
   rubocop (~> 1.79)
   rubocop-capybara
   rubocop-factory_bot
+  rubocop-github-annotations-formatter
   rubocop-graphql
   rubocop-rails
   rubocop-rspec


### PR DESCRIPTION
## Summary
- Added GitHub formatters for RuboCop and Cucumber to display CI results as inline PR annotations
- Configured CI workflow to use these formatters for better developer experience
- RSpec GitHub formatter was already configured and working

## Changes
- Added `rubocop-github-annotations-formatter` gem for RuboCop linting annotations
- Added `cucumber_github_formatter` gem for Cucumber test annotations
- Updated `.github/workflows/ci.yml` to use `--format github` for RuboCop
- Updated `.github/workflows/ci.yml` to use `CucumberGithubFormatter::Formatter` for Cucumber

## Benefits
With these formatters configured, CI failures will now appear as inline annotations directly on PR files:
- ✅ RSpec test failures (already configured)
- ✅ RuboCop linting violations (now configured)
- ✅ Cucumber test failures (now configured)

No more clicking through GitHub Actions logs to find issues - they'll appear right where you need them\!

## Test plan
- [ ] CI runs successfully with the new formatters
- [ ] When tests fail, annotations appear on the PR files
- [ ] When RuboCop finds issues, they appear as inline comments
- [ ] Cucumber failures are properly annotated on relevant files